### PR TITLE
shamend: pass -a to git and default to HEAD

### DIFF
--- a/git/git-shamend
+++ b/git/git-shamend
@@ -22,34 +22,68 @@ set -o nounset
 # THE SOFTWARE.
 
 PrintGitShamendUsage() {
+  echo "Usage: git shamend [options] [<revision>]"
+  echo "Amends your staged changes as a fixup (keeping the pre-existing commit"
+  echo "message) to the specified commit, or HEAD if no revision is specified."
   echo
-  echo "git-shamend amends your staged changes as a fixup (keeping the pre-existing"
-  echo "commit message) to the specified older commit in the current branch."
-  echo
-  echo "USAGE:"
-  echo "stage the changes you want to amend into an earlier commit, then run:"
-  echo "\`git shamend SHA_TO_AMEND\`"
-  echo "(where SHA_TO_AMEND must be the SHA for a commit in the current branch)"
-  echo
+  echo "Options:"
+  echo "    -a, --all             Commit unchanged files, same as git commit."
+  echo "    -h, --help            Print this help."
 }
 
-if [ -z "$*" ]
-then
-  PrintGitShamendUsage
-  exit 1
+ALL=""
+SHA_TO_AMEND=""
+
+# parse arguments
+while [ "$#" -gt 0 ]; do
+  case $1 in
+    -h | --help)
+      PrintGitShamendUsage
+      exit 0
+      ;;
+    -a | --all)
+      ALL="--all"
+      ;;
+    *)
+      if [ -n "$SHA_TO_AMEND" ]; then
+        echo "ERROR: unknown parameter \"$1\""
+        PrintGitShamendUsage
+        exit 1
+      fi
+      SHA_TO_AMEND=$(git rev-parse "$1")
+      if [ ! $? ]; then
+        echo "ERROR: unparsable revision \"$1\""
+        PrintGitShamendUsage
+        exit 1
+      fi
+      ;;
+  esac
+  shift
+done
+
+# fall back to HEAD if no SHA was given
+if [ -z "$SHA_TO_AMEND" ]; then
+  SHA_TO_AMEND="HEAD"
 fi
 
-SHA_TO_AMEND=$(git rev-parse "$@")
+# shortcut the HEAD case for simplicity
+if [ "$SHA_TO_AMEND" = "HEAD" ]; then
+  git commit --amend --no-edit $ALL
+  exit 0
+fi
+
+BOLD=$(tput bold)
+RED=$(tput setaf 1)
+NORMAL=$(tput sgr0)
 
 if git merge-base --is-ancestor $SHA_TO_AMEND HEAD
 then
-  BOLD=$(tput bold)
-  RED=$(tput setaf 1)
-  NORMAL=$(tput sgr0)
 
-  echo "${BOLD}Warning: your unstaged changes will be stashed during this process${NORMAL}"
+  if [ -z "$ALL" ]; then
+    echo "${BOLD}Warning: your unstaged changes will be stashed during this process${NORMAL}"
+  fi
 
-  git commit --fixup $SHA_TO_AMEND > /dev/null
+  git commit $ALL --fixup $SHA_TO_AMEND > /dev/null
 
   git diff-index --quiet HEAD
   NOTHING_TO_STASH=$?
@@ -73,7 +107,7 @@ then
     git stash pop > /dev/null
   fi
 else
+  echo "${RED}${BOLD}${SHA_TO_AMEND} is not an ancestor of HEAD.${NORMAL}"
   PrintGitShamendUsage
   exit 1
 fi
-


### PR DESCRIPTION
Two changes I made to git-shamend that I found useful:
- recognize and pass on '-a' flag to git so you don't (necessarily) have to
  stage your changes if you just want to shamend everything
- if no rev is passed, default to HEAD and just use git's --amend --no-edit
  flags rather than doing the stash/commit/rebase/unstash dance

Motivation: I have 'cm' aliased to shamend and I found it silly that I was now
doing more typing to amend HEAD than I was to amend some further-back commit.

Recognized short-comings:
- I suck at shell and was lazy, so the option parsing is horribly hard-coded
- I didn't add an -h flag (see: lazy) so there's no longer any help output

The short-comings are fixable with a little work, but the current version works
well enough for me and I figured I'd check for interest/acceptability before I
did the work of cleaning it up.
